### PR TITLE
Check for cloned routes only on MacOS

### DIFF
--- a/clonedcheck_bsd.go
+++ b/clonedcheck_bsd.go
@@ -1,0 +1,7 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package netroute
+
+func skipCloned(_ int, _ *rtInfo) bool {
+	return false
+}

--- a/clonedcheck_darwin.go
+++ b/clonedcheck_darwin.go
@@ -1,0 +1,7 @@
+package netroute
+
+import "syscall"
+
+func skipCloned(flags int, routeInfo *rtInfo) bool {
+	return flags&syscall.RTF_CLONING != 0 && routeInfo.Dst.String() == "0.0.0.0/0" && routeInfo.Gateway == nil
+}

--- a/netroute_bsd.go
+++ b/netroute_bsd.go
@@ -115,7 +115,7 @@ func New() (routing.Router, error) {
 		routeInfo.OutputIface = uint32(m.Index)
 
 		// skipping cloned default routes without gateway to avoid choosing a invalid default route
-		if m.Flags&syscall.RTF_CLONING != 0 && routeInfo.Dst.String() == "0.0.0.0/0" && routeInfo.Gateway == nil {
+		if skipCloned(m.Flags, routeInfo) {
 			log.Tracef("skipping cloned default route without gateway: src: %s, dst: %s, interface idx: %d", routeInfo.Src, routeInfo.Dst, routeInfo.OutputIface)
 			continue
 		}


### PR DESCRIPTION
Split the check for BSD and MacOS as newer BSD family doesn't have support for cloned flags